### PR TITLE
名前のみを返すnewStudentList及びregisterStudentクラス(HTML),メソッド(コントローラー)wo

### DIFF
--- a/src/main/java/raiseTech/studentManagement/Controller/StudentController.java
+++ b/src/main/java/raiseTech/studentManagement/Controller/StudentController.java
@@ -4,7 +4,10 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import raiseTech.studentManagement.Controller.Converter.StudentConverter;
 import raiseTech.studentManagement.Data.Student;
 import raiseTech.studentManagement.Data.StudentCourse;
@@ -35,5 +38,21 @@ public class StudentController {
   @GetMapping("/studentCourseList")
   public List<StudentCourse> getStudentCourseList() {
     return service.searchStudentCourseList();
+  }
+
+  @GetMapping("/newStudent")
+  public String newStudent(Model model) {
+    model.addAttribute("studentDetail",new StudentDetail());
+    return "registerStudent";
+  }
+
+
+  @PostMapping("/registerStudent")
+  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "registerStudent";
+    }
+    System.out.println(studentDetail.getStudent().getName() + "さんが追加されました");
+    return "redirect:/studentList";
   }
 }

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http//www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生登録</title>
+</head>
+<body>
+<h1>受講生一覧</h1>
+<form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="name">名前</label>
+    <input type="text" id="name" th:field="*{student.name}" required />
+  </div>
+  <div>
+    <button type="submit">登録</button>
+  </div>
+</form>
+</body>
+</html>


### PR DESCRIPTION
newStudentメソッドを追加し、空のインスタンスを生成後、registerStudentメソッドに値を返す.
registerStudent.htmlにサイトから生徒情報の名前のみを登録できる画面処理を実装。
それをコントローラー(registerStudent)に渡して、値をstudentListに返す処理を行った。