### PR TITLE
29_受講生情報登録処理の実装

### DIFF
--- a/src/main/java/raiseTech/studentManagement/Repository/StudentRepository.java
+++ b/src/main/java/raiseTech/studentManagement/Repository/StudentRepository.java
@@ -22,4 +22,8 @@ public interface StudentRepository {
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void insertStudent(Student student);
 
+  @Insert("INSERT INTO  students_courses (students_id,  courses_name, start_date, expected_end_date)" +
+  "VALUES (#{studentsId}, #{coursesName}, #{startDate}, #{expectedEndDate})")
+  @Options(useGeneratedKeys = true, keyProperty = "coursesId")
+  void insertStudentCourse(StudentCourse studentCourse);
 }

--- a/src/main/java/raiseTech/studentManagement/Service/StudentService.java
+++ b/src/main/java/raiseTech/studentManagement/Service/StudentService.java
@@ -1,5 +1,6 @@
 package raiseTech.studentManagement.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -30,5 +31,11 @@ public class StudentService {
   @Transactional
   public void newInsetStudent(StudentDetail studentDetail) {
    repository.insertStudent(studentDetail.getStudent());
+   for(StudentCourse studentCourse : studentDetail.getStudentCourses()) {
+    studentCourse.setStudentsId(studentDetail.getStudent().getId());
+    studentCourse.setStartDate(LocalDate.now());
+    studentCourse.setExpectedEndDate(LocalDate.now().plusMonths(6));
+    repository.insertStudentCourse(studentCourse);
+   }
   }
 }


### PR DESCRIPTION
生徒コース情報の登録処理でStudentRepositoryにコース登録用のINSERT文を作成、サービスのnewInsetStudent()にコース登録の処理を追加。