### PR TITLE
例外処理ハンドリングクラスにメソッドを追加

### DIFF
--- a/src/main/java/raiseTech/studentManagement/Data/Student.java
+++ b/src/main/java/raiseTech/studentManagement/Data/Student.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,7 +13,7 @@ import lombok.Setter;
 
 public class Student {
 
-  @Min(value = 1, message = "IDは1以上を入力してください")
+  @Min(value = 1, message = "IDは1以上の整数値を入力してください")
   private Long id;
 
   @NotBlank(message = "名前入力は必須です")

--- a/src/main/java/raiseTech/studentManagement/Data/StudentCourse.java
+++ b/src/main/java/raiseTech/studentManagement/Data/StudentCourse.java
@@ -14,6 +14,7 @@ public class StudentCourse {
   @Min(value = 1, message = "コースIDは1以上を入力してください")
   private Long coursesId;
 
+  @Min(value = 1, message = "生徒IDは1以上を入力してください")
   private Long studentsId;
 
   @NotBlank(message = "コース名の登録は必須です")

--- a/src/main/java/raiseTech/studentManagement/ExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/raiseTech/studentManagement/ExceptionHandler/GlobalExceptionHandler.java
@@ -1,9 +1,16 @@
 package raiseTech.studentManagement.ExceptionHandler;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import raiseTech.studentManagement.Exception.TestStudentListException;
 import raiseTech.studentManagement.Exception.StudentNotFoundException;
 
@@ -13,7 +20,6 @@ public class GlobalExceptionHandler  {
 
   /**
    * {@link StudentNotFoundException}を処理
-   *
    * @param ex 存在しない生徒のidに対して発生した例外
    * @return HTTPステータスと例外メッセージ
    */
@@ -22,6 +28,68 @@ public class GlobalExceptionHandler  {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
   }
 
+  /**
+   * コントローラーのid検索で文字列や少数が入力された際の処理
+   * @param ex 文字列や少数が入力された際の例外
+   * @return HTTPステータスと例外メッセージ
+   */
+  @ExceptionHandler(NumberFormatException.class)
+  public ResponseEntity<String> handleNumberFormatException(NumberFormatException ex) {
+    String message = "IDは1以上の整数値を入力してください";
+    return  ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
+  }
+
+  /**
+   * バリデーションエラー(@PathVariable,@RequestParam)があった際の処理
+   * コントローラーのid検索時に－の値が入力された際の処理
+   * @param ex バリデーションエラーがあったオブジェクトのフィールド
+   * @return HTTPステータスとバリデーションエラーの変数名,例外メッセージ
+   */
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<Map<String,String>> handleConstraintViolationException(ConstraintViolationException ex) {
+    Map<String,String> errors = new HashMap<>();
+
+    //オブジェクトを指定しない(ワイルドカード)ConstraintViolation型のviolationに１つ以上のバリデーションエラーのリストを代入してループ
+    for(ConstraintViolation<?> violation : ex.getConstraintViolations()) {
+
+      //String型の変数fieldNameにバリデーションエラーのフィールドパスを文字列化して代入
+      String fieldName = violation.getPropertyPath().toString();
+
+      //String型の変数paramNameに文字列化したバリデーションエラーのフィールドパスの.以降(変数名)を代入
+      String paramName = fieldName.substring(fieldName.lastIndexOf('.') +1);
+
+      //Map型の変数errorにバリデーションエラー箇所の変数名とエラーメッセージを追加
+      errors.put(paramName, violation.getMessage());
+    }
+    return new ResponseEntity<>(errors,HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * バリデーションエラー(@RequestBody)があった際の処理
+   * コントローラーの生徒情報更新の際に想定外の値が入力された際の処理
+   * @param ex　バリデーションエラーがあったオブジェクトのフィールド
+   * @param request　
+   * @return HTTPステータスとバリデーションエラーの変数名,例外メッセージ
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<Map<String,String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, WebRequest request) {
+    Map<String,String> errors = new HashMap<>();
+
+    //FieldErrorはMethodArgumentNotValidExceptionクラスが持つリスト型
+    //MethodArgumentNotValidExceptionはバインディングリザルトを持っていてそこからgetFieldErrors(エラーフィールドを取得)
+    for(FieldError error : ex.getBindingResult().getFieldErrors()) {
+
+      //String型の変数fieldNameにバリデーションエラーのフィールドパスを代入
+      String fieldName = error.getField();
+
+      //String型の変数paramNameに文字列化したバリデーションエラーのフィールドパスの.以降(変数名)を代入
+      String paramName = fieldName.substring(fieldName.lastIndexOf('.') +1);
+
+      //Map型の変数errorにバリデーションエラー箇所の変数名とエラーメッセージを追加
+      errors.put(paramName,error.getDefaultMessage());
+    }
+    return new ResponseEntity<>(errors,HttpStatus.BAD_REQUEST);
+  }
 
   //テスト用
   @ExceptionHandler(TestStudentListException.class)


### PR DESCRIPTION
GlobalExceptionHandlerクラスにhandleConstraintViolationExceptionとhandleNumberFormatExceptionを追加。

上記2つのメソッドはidでの生徒単一検索時にバリデーションエラーがあった際の例外処理のために実装。

GlobalExceptionHandlerクラスに
handleMethodArgumentNotValidExceptionを追加。
このメソッドは生徒情報更新時にバリデーションエラーがあった際の例外処理のために実装

上記３つのバリデーションエラーの例外処理の変更に伴いStudentクラスとStudentCourseクラスのバリデーションを変更。